### PR TITLE
Update services.yml

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -34,7 +34,7 @@ services:
 
     # The encryptor service created by the factory according to the passed method and using the encrypt_key
     SpecShaper\EncryptBundle\Encryptors\EncryptorService:
-        factory: ['SpecShaper\EncryptBundle\Encryptors\EncryptorFactory','createService']
+        factory: ['@SpecShaper\EncryptBundle\Encryptors\EncryptorFactory','createService']
         arguments:
             - '%spec_shaper_encrypt.method%'
             - '%spec_shaper_encrypt.encrypt_key%'


### PR DESCRIPTION
Fixing missing @ for service. Resolves this deprecation notice: php.INFO: Deprecated: Non-static method SpecShaper\EncryptBundle\Encryptors\EncryptorFactory::createService() should not be called statically {"exception":"[object] (ErrorException(code: 0): Deprecated: Non-static method SpecShaper\\EncryptBundle\\Encryptors\\EncryptorFactory::createService() should not be called statically at /var/www/project/var/cache/prod/ContainerXZEa0sE/getEncryptorServiceService.php:11)"