### PR TITLE
Fixing service factory, update twig version supporting

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -34,7 +34,7 @@ services:
 
     # The encryptor service created by the factory according to the passed method and using the encrypt_key
     SpecShaper\EncryptBundle\Encryptors\EncryptorService:
-        factory: 'SpecShaper\EncryptBundle\Encryptors\EncryptorFactory:createService'
+        factory: ['@SpecShaper\EncryptBundle\Encryptors\EncryptorFactory','createService']
         arguments:
             - '%spec_shaper_encrypt.method%'
             - '%spec_shaper_encrypt.encrypt_key%'

--- a/Twig/EncryptExtension.php
+++ b/Twig/EncryptExtension.php
@@ -3,9 +3,11 @@
 namespace SpecShaper\EncryptBundle\Twig;
 
 use SpecShaper\EncryptBundle\Encryptors\EncryptorInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
 
 
-class EncryptExtension extends \Twig_Extension
+class EncryptExtension extends AbstractExtension
 {
     /**
      * @var EncryptorInterface
@@ -20,7 +22,7 @@ class EncryptExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            new \Twig_SimpleFilter('decrypt', array($this, 'decryptFilter'))
+            new TwigFilter('decrypt', array($this, 'decryptFilter'))
         );
     }
 


### PR DESCRIPTION
#1 fixing service factory to prevent next error:  Cannot dump definition because of invalid class name ('SpecShaper\\EncryptBundle\\Encryptors\\EncryptorFactory:createService').

#2 Adding support twig >= 2.7.0 instead of old ones as more actual for s5