### PR TITLE
Encrypted values get re-encrypted

### DIFF
--- a/Subscribers/DoctrineEncryptSubscriber.php
+++ b/Subscribers/DoctrineEncryptSubscriber.php
@@ -275,8 +275,11 @@ class DoctrineEncryptSubscriber implements EventSubscriber, DoctrineEncryptSubsc
                 throw new EncryptException('You cannot encrypt an object at ' . $refProperty->class .':'.  $refProperty->getName() , $value);
             }
 
-            // If the required operation is to encrypt then encrypt the value.
-            if($isEncryptOperation) {
+            // If the required operation is to encrypt then encrypt the value, but only if it's not already encrypted
+            if(
+                    $isEncryptOperation
+                &&  self::ENCRYPTED_SUFFIX !== substr($value, -5)
+            ) {
                 $encryptedValue = $this->encryptor->encrypt($value);
                 $refProperty->setValue($entity, $encryptedValue);
             } else {


### PR DESCRIPTION
So, it seems and most definitely is that You the bundle simply encrypts the value no matter if it was encrypted or not. I found and issue when I did this:
- Project `A`:
   -  contain some data,
   - data is encrypted before sending to api,
   - api call is done to project `B`,
- Project `B`
   - runs into timeout (clearly php_ini stuff, but that's not the point),
   - partially imported data is not working

So the timeout happens because the `B` encrypts tones of the data again.
Imported data is not working since the already encrypted data get's re-encrypted.