### PR TITLE
Optimize large set of processed data for API calls

### DIFF
--- a/Subscribers/DoctrineEncryptSubscriber.php
+++ b/Subscribers/DoctrineEncryptSubscriber.php
@@ -180,6 +180,7 @@ class DoctrineEncryptSubscriber implements EventSubscriber, DoctrineEncryptSubsc
         foreach ($this->postFlushDecryptQueue as $entity) {
             $this->processFields($entity, $args->getEntityManager(), false);
             $this->addToDecodedRegistry($entity);
+            $args->getEntityManager()->detach($entity); // detach due to excessive data insertion becomming slow
         }
 
         $this->postFlushDecryptQueue = array();


### PR DESCRIPTION
I was trying to localize the bottleneck in my API calls. That's the one

**Without that:**
- **Start**: 17:57:40
- **End**: 17:59:28
- **Duration**: 1min 48s
- **Result**: not even half gets transferred and each call gets slower.... and slower... had eventually timeouts

**With that:**
- **Start**: 18:05:29
- **End**: 18:06:06
- **Duration**: 37s
- **Result**: done, everything works