### PR TITLE
fix deprecation notices

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -15,7 +15,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 class Configuration implements ConfigurationInterface
 {
     /**
-     * {@inheritdoc}
+     * @return TreeBuilder
      */
     public function getConfigTreeBuilder()
     {

--- a/Twig/EncryptExtension.php
+++ b/Twig/EncryptExtension.php
@@ -19,6 +19,9 @@ class EncryptExtension extends AbstractExtension
         $this->encryptor = $encryptor;
     }
 
+    /**
+     * @return TwigFilter[]
+     */
     public function getFilters()
     {
         return array(


### PR DESCRIPTION
There are some deprecation notices using symfony 5.4.2.

* Method "Twig\Extension\ExtensionInterface::getFilters()" might add "array" as a native return type declaration in the future. Do the same in implementation "SpecShaper\EncryptBundle\Twig\EncryptExtension" now to avoid errors or add an explicit @return annotation to suppress this message.

* Method "Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder()" might add "TreeBuilder" as a native return type declaration in the future. Do the same in implementation "SpecShaper\EncryptBundle\DependencyInjection\Configuration" now to avoid errors or add an explicit @return annotation to suppress this message.

Thank you
