### PR TITLE
fix deprecation notices - Added explicit @return annotation

### DIFF
--- a/Command/GenKeyCommand.php
+++ b/Command/GenKeyCommand.php
@@ -32,6 +32,9 @@ class GenKeyCommand extends Command
 
     }
 
+    /**
+     * @return int|void
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $encryption_key_256bit = base64_encode(openssl_random_pseudo_bytes(32));


### PR DESCRIPTION
Fixed deprecation notice using symfony 5.4.2:

- [x] 1x: Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "SpecShaper\EncryptBundle\Command\GenKeyCommand" now to avoid errors or add an explicit @return annotation to suppress this message.