### PR TITLE
Add doctrine/annotations to require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "php": ">=8",
         "symfony/framework-bundle": "^5.4|^6.0",
         "symfony/console": "^5.4|^6.0",
+        "doctrine/annotations": "^1.8|^2.0",
         "doctrine/orm": "^2.11",
         "doctrine/doctrine-bundle": "^2.5",
         "symfony/monolog-bundle": "^3.7"


### PR DESCRIPTION
As Doctrine\Common\Annotations\Reader is part of the doctrine/annotations package, this is a hard requirement for this package as DoctrineEncryptSubscriber uses it.

Without this i got the following error on a fresh symfony install:
> Executing script cache:clear [KO]
>  [KO]
> Script cache:clear returned with error code 1
> !!  
> !!  In DefinitionErrorExceptionPass.php line 51:
> !!                                                                                 
> !!    Cannot autowire service "SpecShaper\EncryptBundle\Subscribers\DoctrineEncry  
> !!    ptSubscriberInterface": argument "$annReader" of method "SpecShaper\Encrypt  
> !!    Bundle\Subscribers\DoctrineEncryptSubscriber::__construct()" has type "Doct  
> !!    rine\Common\Annotations\Reader" but this class was not found.                
> !!                                                                                 
> !!  
> !!  
> Script @auto-scripts was called via post-install-cmd