### PR TITLE
Proposed fixes for `EncryptDatabaseCommand`

### DIFF
--- a/src/Command/EncryptDatabaseCommand.php
+++ b/src/Command/EncryptDatabaseCommand.php
@@ -5,7 +5,6 @@ namespace SpecShaper\EncryptBundle\Command;
 use Doctrine\Migrations\Query\Query;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Persistence\ManagerRegistry;
-use Doctrine\Persistence\Reflection\RuntimeReflectionProperty;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
@@ -148,7 +147,8 @@ class EncryptDatabaseCommand extends Command
 
             foreach ($meta->getReflectionProperties() as $key => $refProperty) {
                 if ($this->isEncryptedProperty($refProperty)) {
-                    $this->encryptedFields[$tableName][$key] = $refProperty;
+                    $columnName = $meta->getColumnName($key);
+                    $this->encryptedFields[$tableName][$columnName] = $refProperty;
                 }
             }
         }
@@ -156,7 +156,7 @@ class EncryptDatabaseCommand extends Command
         return $this->encryptedFields;
     }
 
-    private function isEncryptedProperty(RuntimeReflectionProperty $refProperty)
+    private function isEncryptedProperty(\ReflectionProperty $refProperty)
     {
 
         foreach ($refProperty->getAttributes() as $refAttribute) {

--- a/tests/Unit/Command/GenKeyCommandTest.php
+++ b/tests/Unit/Command/GenKeyCommandTest.php
@@ -8,7 +8,7 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 
-class DomBuilderFactoryTest extends TestCase
+class GenKeyCommandTest extends TestCase
 {
     /**
      * Test that an encryption key of 43 characters (ending with =) is created.


### PR DESCRIPTION
- Replace `RuntimeReflectionProperty` with `\ReflectionProperty`
- Use column name instead of property name as array key (for generated SQL)