### PR TITLE
Fix en-/decryption command

### DIFF
--- a/src/Command/EncryptDatabaseCommand.php
+++ b/src/Command/EncryptDatabaseCommand.php
@@ -143,8 +143,8 @@ class EncryptDatabaseCommand extends Command
                         $this->encryptedFields[$tableName] = [];
                     }
 
-                    $columnName = $classMeta->getColumnName($key);
-                    $this->encryptedFields[$tableName][$columnName] = $refProperty->getName();
+                    $columnName = $classMeta->getColumnName($refProperty->getName());
+                    $this->encryptedFields[$tableName][$refProperty->getName()] = $columnName;
                 }
             }
         }


### PR DESCRIPTION
This fixes an issue with properties like `$someInformation` where doctrine makes the column name to `some_information` and the command cannot find the column `someInformation` in the database

```
Column not found: 1054 Unknown column 'someInformation' in 'SELECT'
```