### PR TITLE
Use event's ObjectManager instead of injected EntityManager in DoctrineEncryptListener

### DIFF
--- a/src/EventListener/DoctrineEncryptListener.php
+++ b/src/EventListener/DoctrineEncryptListener.php
@@ -41,9 +41,11 @@ class DoctrineEncryptListener implements DoctrineEncryptListenerInterface
 
     private bool $isDisabled;
 
+    /**
+     * @param EntityManagerInterface $em Deprecated in favour of fetching object manager from event args.
+     */
     public function __construct(
         private readonly EncryptorInterface $encryptor,
-        #[\Deprecated]
         private readonly EntityManagerInterface $em,
         array $annotationArray,
         bool $isDisabled

--- a/src/EventListener/DoctrineEncryptListenerInterface.php
+++ b/src/EventListener/DoctrineEncryptListenerInterface.php
@@ -13,10 +13,12 @@ use SpecShaper\EncryptBundle\Encryptors\EncryptorInterface;
 interface DoctrineEncryptListenerInterface
 {
     public const ENCRYPTED_SUFFIX = '<ENC>';
-
+    
+    /**
+     * @param EntityManagerInterface $em Deprecated in favour of getting object manager from event args.
+     */
     public function __construct(
         EncryptorInterface $encryptor,
-        #[\Deprecated]
         EntityManagerInterface $em,
         array $annotationArray,
         bool $isDisabled

--- a/src/EventListener/DoctrineEncryptListenerInterface.php
+++ b/src/EventListener/DoctrineEncryptListenerInterface.php
@@ -16,6 +16,7 @@ interface DoctrineEncryptListenerInterface
 
     public function __construct(
         EncryptorInterface $encryptor,
+        #[\Deprecated]
         EntityManagerInterface $em,
         array $annotationArray,
         bool $isDisabled


### PR DESCRIPTION
The DoctrineEncryptListener is currently using the default injected EntityManager.  This caused errors when working with entities coming from another EntityManager of the default one (for example, we use this bundle in a modular monolith application, where each module is managed by its own EntityManager).

This PR refactors the DoctrineEncryptListener to use the ObjectManager from the event arguments  instead of the injected EntityManager instance. So it will use the EntityManager related to the processing entity.