### PR TITLE
Fix Symfony 8.1 deprecation

### DIFF
--- a/src/DependencyInjection/SpecShaperEncryptExtension.php
+++ b/src/DependencyInjection/SpecShaperEncryptExtension.php
@@ -8,8 +8,8 @@ use SpecShaper\EncryptBundle\EventListener\EncryptEventListener;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Extension\Extension
 use Symfony\Component\DependencyInjection\Loader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * This is the class that loads and manages your bundle configuration.


### PR DESCRIPTION
`The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice. You should not use it from "SpecShaper\EncryptBundle\DependencyInjection\SpecShaperEncryptExtension".`

replace Symfony\Component\HttpKernel\DependencyInjection\Extension with Symfony\Component\DependencyInjection\Extension\Extension