### PR TITLE
Add blind index support for encrypted fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Maker will have created a packages yaml file. The key is resolved in there.
 # app/config/packages/spec_shaper_encrypt.yaml
 spec_shaper_encrypt:
   encrypt_key: '%env(SPEC_SHAPER_ENCRYPT_KEY)%'
+  blind_index_key: '%env(SPEC_SHAPER_BLIND_INDEX_KEY)%' # Optional, defaults to encrypt_key when omitted.
   is_disabled: false # Turn this to true to disable the encryption.
   connections:   # Optional, define the connection name(s) for the listener
     - 'default'
@@ -112,6 +113,60 @@ If you want to define your own annotation/attribute, then this can be used to tr
 class name to the 'annotation_classes' option array.
 
 You can pass the class name of your own encyptor service using the optional encryptorClass option.
+
+### Unique constraints and lookups on encrypted values
+
+Encrypted values are randomized, so the same plaintext value will normally produce a different encrypted value every time.
+Do not put a useful unique constraint on the encrypted column itself. Instead, map a separate blind-index field and put the
+database unique constraint on that field.
+
+```php
+<?php
+
+use Doctrine\ORM\Mapping as ORM;
+use SpecShaper\EncryptBundle\Annotations\BlindIndex;
+use SpecShaper\EncryptBundle\Annotations\Encrypted;
+
+#[ORM\Column(type: 'string')]
+#[Encrypted]
+private string $email;
+
+#[ORM\Column(type: 'string', length: 64, unique: true, nullable: true)]
+#[BlindIndex(
+    sourceField: 'email',
+    normalizer: BlindIndex::NORMALIZE_LOWERCASE
+)]
+private ?string $emailLookupHash = null;
+```
+
+When `email` changes, the Doctrine listener encrypts the email and writes
+`hash_hmac('sha256', normalized email, blind_index_key)` to `emailLookupHash`.
+
+Available normalizers are:
+
+- `BlindIndex::NORMALIZE_NONE`
+- `BlindIndex::NORMALIZE_TRIM`
+- `BlindIndex::NORMALIZE_LOWERCASE`
+- `BlindIndex::NORMALIZE_UPPERCASE`
+
+You can also inject `SpecShaper\EncryptBundle\Hashers\BlindIndexHasherInterface` when you need to query by the encrypted
+value:
+
+```php
+$hash = $blindIndexHasher->hash('test@example.com', BlindIndex::NORMALIZE_LOWERCASE);
+
+$user = $userRepository->findOneBy([
+    'emailLookupHash' => $hash,
+]);
+```
+
+For best separation, configure `blind_index_key` with a secret distinct from `encrypt_key`.
+
+To build or rebuild lookup hashes for existing database rows, run:
+
+```
+$ bin/console encrypt:blind-index --manager=default
+```
 
 ### Alternative EncryptKeyEvent
 The EncryptKey can be set via a dispatched event listener, which overrides any .env or param.yml defined key.
@@ -295,4 +350,3 @@ $ bin/console encrypt:database decrypt connection
 The requried argument should be decrypt or encrypt.
 
 There is an option to define the database connection if you employ multiple connections in your application.
-

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -39,10 +39,22 @@ services:
             $encryptKey: '%spec_shaper_encrypt.encrypt_key%'
             $encryptorClass: '%spec_shaper_encrypt.encryptor_class%'
 
+    SpecShaper\EncryptBundle\Hashers\BlindIndexHasherInterface:
+        class: SpecShaper\EncryptBundle\Hashers\HmacBlindIndexHasher
+        arguments:
+            $key: '%spec_shaper_encrypt.blind_index_key%'
+
+    SpecShaper\EncryptBundle\BlindIndex\BlindIndexMetadataProvider: ~
+
+    SpecShaper\EncryptBundle\BlindIndex\BlindIndexUpdater: ~
+
     # CLI command to encrypt or decrypt all fields in a database
     SpecShaper\EncryptBundle\Command\EncryptDatabaseCommand:
         arguments:
             $annotationArray: '%spec_shaper_encrypt.annotation_classes%'
+
+    # CLI command to build or rebuild blind index fields
+    SpecShaper\EncryptBundle\Command\BlindIndexDatabaseCommand: ~
 
     # CLI command to generate a 256 bit encryption key
     SpecShaper\EncryptBundle\Command\GenKeyCommand:

--- a/src/Annotations/BlindIndex.php
+++ b/src/Annotations/BlindIndex.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SpecShaper\EncryptBundle\Annotations;
+
+use Attribute;
+use Doctrine\Common\Annotations\Annotation;
+
+/**
+ * @Annotation
+ * @Target("ALL")
+ */
+#[\Attribute(Attribute::TARGET_PROPERTY)]
+final class BlindIndex
+{
+    public const NORMALIZE_NONE = 'none';
+    public const NORMALIZE_TRIM = 'trim';
+    public const NORMALIZE_LOWERCASE = 'lowercase';
+    public const NORMALIZE_UPPERCASE = 'uppercase';
+
+    public function __construct(
+        private readonly string $sourceField,
+        private readonly string $normalizer = self::NORMALIZE_NONE
+    ) {
+    }
+
+    public function getSourceField(): string
+    {
+        return $this->sourceField;
+    }
+
+    public function getNormalizer(): string
+    {
+        return $this->normalizer;
+    }
+}

--- a/src/Annotations/Encrypted.php
+++ b/src/Annotations/Encrypted.php
@@ -13,4 +13,3 @@ use Doctrine\Common\Annotations\Annotation;
 final class Encrypted
 {
 }
-

--- a/src/BlindIndex/BlindIndexField.php
+++ b/src/BlindIndex/BlindIndexField.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace SpecShaper\EncryptBundle\BlindIndex;
+
+use ReflectionProperty;
+
+final class BlindIndexField
+{
+    public function __construct(
+        private readonly string $field,
+        private readonly ReflectionProperty $property,
+        private readonly string $sourceField,
+        private readonly ReflectionProperty $sourceProperty,
+        private readonly string $normalizer
+    ) {
+    }
+
+    public function getField(): string
+    {
+        return $this->field;
+    }
+
+    public function getProperty(): ReflectionProperty
+    {
+        return $this->property;
+    }
+
+    public function getSourceField(): string
+    {
+        return $this->sourceField;
+    }
+
+    public function getSourceProperty(): ReflectionProperty
+    {
+        return $this->sourceProperty;
+    }
+
+    public function getNormalizer(): string
+    {
+        return $this->normalizer;
+    }
+}

--- a/src/BlindIndex/BlindIndexMetadataProvider.php
+++ b/src/BlindIndex/BlindIndexMetadataProvider.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace SpecShaper\EncryptBundle\BlindIndex;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\Persistence\ObjectManager;
+use SpecShaper\EncryptBundle\Annotations\BlindIndex;
+use SpecShaper\EncryptBundle\Exception\EncryptException;
+
+final class BlindIndexMetadataProvider
+{
+    /**
+     * @var array<string, array<string, BlindIndexField>>
+     */
+    private array $cache = [];
+
+    /**
+     * @return array<string, array<string, BlindIndexField>>
+     */
+    public function getAllForObjectManager(ObjectManager $objectManager): array
+    {
+        $blindIndexFields = [];
+
+        /** @var ClassMetadata[] $metadata */
+        $metadata = $objectManager->getMetadataFactory()->getAllMetadata();
+
+        foreach ($metadata as $classMeta) {
+            if ($classMeta->isMappedSuperclass) {
+                continue;
+            }
+
+            $fields = $this->getForClassMetadata($classMeta);
+
+            if (!empty($fields)) {
+                $blindIndexFields[$classMeta->getName()] = $fields;
+            }
+        }
+
+        return $blindIndexFields;
+    }
+
+    /**
+     * @return array<string, BlindIndexField>
+     */
+    public function getForEntity(ObjectManager $objectManager, object $entity): array
+    {
+        /** @var ClassMetadata $classMeta */
+        $classMeta = $objectManager->getClassMetadata(get_class($entity));
+
+        return $this->getForClassMetadata($classMeta);
+    }
+
+    /**
+     * @return array<string, BlindIndexField>
+     */
+    public function getForClassMetadata(ClassMetadata $classMeta): array
+    {
+        $className = $classMeta->getName();
+
+        if (isset($this->cache[$className])) {
+            return $this->cache[$className];
+        }
+
+        $reflectionClass = new \ReflectionClass($className);
+        $blindIndexFields = [];
+
+        foreach ($reflectionClass->getProperties() as $refProperty) {
+            foreach ($refProperty->getAttributes(BlindIndex::class) as $refAttribute) {
+                /** @var BlindIndex $attribute */
+                $attribute = $refAttribute->newInstance();
+                $field = $refProperty->getName();
+                $sourceField = $attribute->getSourceField();
+
+                if (!$classMeta->hasField($sourceField)) {
+                    throw new EncryptException(sprintf('Blind index source field "%s" is not mapped on "%s".', $sourceField, $className));
+                }
+
+                if (!$classMeta->hasField($field)) {
+                    throw new EncryptException(sprintf('Blind index field "%s" is not mapped on "%s".', $field, $className));
+                }
+
+                $blindIndexFields[$field] = new BlindIndexField(
+                    $field,
+                    $classMeta->getReflectionProperty($field),
+                    $sourceField,
+                    $classMeta->getReflectionProperty($sourceField),
+                    $attribute->getNormalizer()
+                );
+            }
+        }
+
+        $this->cache[$className] = $blindIndexFields;
+
+        return $blindIndexFields;
+    }
+}

--- a/src/BlindIndex/BlindIndexUpdater.php
+++ b/src/BlindIndex/BlindIndexUpdater.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace SpecShaper\EncryptBundle\BlindIndex;
+
+use SpecShaper\EncryptBundle\Exception\EncryptException;
+use SpecShaper\EncryptBundle\Hashers\BlindIndexHasherInterface;
+
+final class BlindIndexUpdater
+{
+    public function __construct(
+        private readonly BlindIndexHasherInterface $blindIndexHasher
+    ) {
+    }
+
+    /**
+     * @param array<string, BlindIndexField> $blindIndexFields
+     * @param array<string, mixed>|null      $changedFields
+     */
+    public function update(object $entity, array $blindIndexFields, ?array $changedFields = null): bool
+    {
+        $hasUpdated = false;
+
+        foreach ($blindIndexFields as $blindIndexField) {
+            if (null !== $changedFields && !array_key_exists($blindIndexField->getSourceField(), $changedFields)) {
+                continue;
+            }
+
+            $sourceValue = $blindIndexField->getSourceProperty()->getValue($entity);
+
+            if (is_object($sourceValue)) {
+                throw new EncryptException(sprintf('Cannot create blind index from an object at %s:%s', get_class($entity), $blindIndexField->getSourceField()));
+            }
+
+            $blindIndexField->getProperty()->setValue(
+                $entity,
+                $this->blindIndexHasher->hash($sourceValue, $blindIndexField->getNormalizer())
+            );
+
+            $hasUpdated = true;
+        }
+
+        return $hasUpdated;
+    }
+}

--- a/src/Command/BlindIndexDatabaseCommand.php
+++ b/src/Command/BlindIndexDatabaseCommand.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace SpecShaper\EncryptBundle\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use SpecShaper\EncryptBundle\BlindIndex\BlindIndexMetadataProvider;
+use SpecShaper\EncryptBundle\BlindIndex\BlindIndexUpdater;
+use SpecShaper\EncryptBundle\Exception\EncryptException;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * bin/console encrypt:blind-index --manager=default
+ */
+#[AsCommand(
+    name: 'encrypt:blind-index',
+    description: 'Builds or rebuilds blind index columns'
+)]
+class BlindIndexDatabaseCommand extends Command
+{
+    public function __construct(
+        private readonly ManagerRegistry $registry,
+        private readonly BlindIndexMetadataProvider $blindIndexMetadataProvider,
+        private readonly BlindIndexUpdater $blindIndexUpdater
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('manager', null, InputOption::VALUE_OPTIONAL, 'Nominate the database connection manager name.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $managerName = $this->registry->getDefaultManagerName();
+        $managerNameOption = $input->getOption('manager');
+
+        if (!empty($managerNameOption)) {
+            $managerName = $managerNameOption;
+        }
+
+        $em = $this->registry->getManager($managerName);
+
+        if (!$em instanceof EntityManagerInterface) {
+            throw new EncryptException(sprintf('Manager "%s" is not a Doctrine ORM entity manager.', $managerName));
+        }
+
+        $blindIndexFields = $this->blindIndexMetadataProvider->getAllForObjectManager($em);
+
+        $io->title('Building blind indexes');
+
+        $classes = count($blindIndexFields);
+
+        $io->writeln($classes.' classes to update');
+        $io->progressStart($classes);
+
+        foreach ($blindIndexFields as $className => $fieldArray) {
+            $this->updateEntities($em, $className, $fieldArray);
+            $io->progressAdvance();
+        }
+
+        $io->progressFinish();
+
+        return Command::SUCCESS;
+    }
+
+    private function updateEntities(EntityManagerInterface $em, string $className, array $fieldArray): void
+    {
+        $query = $em->createQueryBuilder()
+            ->select('entity')
+            ->from($className, 'entity')
+            ->getQuery()
+        ;
+
+        foreach ($query->toIterable() as $entity) {
+            $this->blindIndexUpdater->update($entity, $fieldArray);
+
+            $em->flush();
+            $em->detach($entity);
+        }
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -24,6 +24,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('encrypt_key')->end()
+                ->scalarNode('blind_index_key')->defaultValue(null)->end()
                 ->scalarNode('default_associated_data')->defaultValue(null)->end()
                 ->scalarNode('method')->defaultValue('OpenSSL')->end()
                 ->scalarNode('listener_class')->defaultValue(DoctrineEncryptListener::class)->end()

--- a/src/DependencyInjection/SpecShaperEncryptExtension.php
+++ b/src/DependencyInjection/SpecShaperEncryptExtension.php
@@ -33,7 +33,10 @@ class SpecShaperEncryptExtension extends Extension
             $encryptKey = $config['encrypt_key'];
         }
 
+        $blindIndexKey = $config['blind_index_key'] ?? $encryptKey;
+
         $container->setParameter($this->getAlias().'.encrypt_key', $encryptKey);
+        $container->setParameter($this->getAlias().'.blind_index_key', $blindIndexKey);
         $container->setParameter($this->getAlias().'.default_associated_data', $config['default_associated_data']);
         $container->setParameter($this->getAlias().'.method', $config['method']);
         $container->setParameter($this->getAlias().'.listener_class', $config['listener_class']);

--- a/src/EventListener/DoctrineEncryptListener.php
+++ b/src/EventListener/DoctrineEncryptListener.php
@@ -8,6 +8,8 @@ use Doctrine\ORM\Events;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Persistence\ObjectManager;
 use ReflectionProperty;
+use SpecShaper\EncryptBundle\BlindIndex\BlindIndexMetadataProvider;
+use SpecShaper\EncryptBundle\BlindIndex\BlindIndexUpdater;
 use SpecShaper\EncryptBundle\Encryptors\EncryptorInterface;
 use SpecShaper\EncryptBundle\Exception\EncryptException;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
@@ -48,7 +50,9 @@ class DoctrineEncryptListener implements DoctrineEncryptListenerInterface
         private readonly EncryptorInterface $encryptor,
         private readonly EntityManagerInterface $em,
         array $annotationArray,
-        bool $isDisabled
+        bool $isDisabled,
+        private readonly ?BlindIndexMetadataProvider $blindIndexMetadataProvider = null,
+        private readonly ?BlindIndexUpdater $blindIndexUpdater = null
     ) {
         $this->annotationArray = $annotationArray;
         $this->isDisabled = $isDisabled;
@@ -135,19 +139,30 @@ class DoctrineEncryptListener implements DoctrineEncryptListenerInterface
     /**
      * Process (encrypt/decrypt) entities fields.
      */
-    protected function processFields(ObjectManager $objectManager,object $entity, bool $isEncryptOperation, bool $isInsert): bool
+    protected function processFields(ObjectManager $objectManager, object $entity, bool $isEncryptOperation, bool $isInsert): bool
     {
         // Get the encrypted properties in the entity.
         $properties = $this->getEncryptedFields($objectManager, $entity);
+        $blindIndexes = $this->blindIndexMetadataProvider?->getForEntity($objectManager, $entity) ?? [];
 
         // If no encrypted properties, return false.
-        if (empty($properties)) {
+        if (empty($properties) && empty($blindIndexes)) {
             return false;
         }
 
         $unitOfWork = $objectManager->getUnitOfWork();
         $oid = spl_object_id($entity);
         $meta = $objectManager->getClassMetadata(get_class($entity));
+        $changeSet = $unitOfWork->getEntityChangeSet($entity);
+        $blindIndexesUpdated = false;
+
+        if ($isEncryptOperation && !empty($blindIndexes)) {
+            if (null === $this->blindIndexUpdater) {
+                throw new EncryptException('Cannot create blind indexes; no blind index updater is configured.');
+            }
+
+            $blindIndexesUpdated = $this->blindIndexUpdater->update($entity, $blindIndexes, $changeSet);
+        }
 
         foreach ($properties as $refProperty) {
 
@@ -156,29 +171,30 @@ class DoctrineEncryptListener implements DoctrineEncryptListenerInterface
             // Get the value in the entity.
             $value = $refProperty->getValue($entity);
 
-            // Skip any null values.
-            if (null === $value) {
-                continue;
-            }
-
             if (is_object($value)) {
                 throw new EncryptException('Cannot encrypt an object at '.$refProperty->class.':'.$refProperty->getName(), $value);
             }
 
             // Encryption is fired by onFlush event, else it is an onLoad event.
             if ($isEncryptOperation) {
-                $changeSet = $unitOfWork->getEntityChangeSet($entity);
-
                 // Encrypt value only if change has been detected by Doctrine (comparing unencrypted values, see postLoad flow)
                 if (isset($changeSet[$field])) {
-                    $encryptedValue = $this->encryptor->encrypt($value, $field);
-                    $refProperty->setValue($entity, $encryptedValue);
-                    $unitOfWork->recomputeSingleEntityChangeSet($meta, $entity);
+                    if (null !== $value) {
+                        $encryptedValue = $this->encryptor->encrypt($value, $field);
+                        $refProperty->setValue($entity, $encryptedValue);
 
-                    // Will be restored during postUpdate cycle for updates, or below for inserts
-                    $this->rawValues[$oid][$field] = $value;
+                        // Will be restored during postUpdate cycle for updates, or below for inserts
+                        $this->rawValues[$oid][$field] = $value;
+                    }
+
+                    $unitOfWork->recomputeSingleEntityChangeSet($meta, $entity);
                 }
             } else {
+                // Skip any null values.
+                if (null === $value) {
+                    continue;
+                }
+
                 // Decryption is fired by onLoad and postFlush events.
                 $decryptedValue = $this->decryptValue($value, $field);
                 $refProperty->setValue($entity, $decryptedValue);
@@ -186,6 +202,10 @@ class DoctrineEncryptListener implements DoctrineEncryptListenerInterface
                 // Tell Doctrine the original value was the decrypted one.
                 $unitOfWork->setOriginalEntityProperty($oid, $field, $decryptedValue);
             }
+        }
+
+        if ($isEncryptOperation && $blindIndexesUpdated) {
+            $unitOfWork->recomputeSingleEntityChangeSet($meta, $entity);
         }
 
         if ($isInsert && isset($this->rawValues[$oid])) {
@@ -238,7 +258,6 @@ class DoctrineEncryptListener implements DoctrineEncryptListenerInterface
         $encryptedFields = [];
 
         foreach ($properties as $key => $refProperty) {
-
             if ($this->isEncryptedProperty($refProperty)) {
                 $encryptedFields[$key] = $refProperty;
             }
@@ -249,7 +268,7 @@ class DoctrineEncryptListener implements DoctrineEncryptListenerInterface
         return $encryptedFields;
     }
 
-    private function isEncryptedProperty(ReflectionProperty $refProperty)
+    private function isEncryptedProperty(ReflectionProperty $refProperty): bool
     {
 
         // If PHP8, and has attributes.

--- a/src/Hashers/BlindIndexHasherInterface.php
+++ b/src/Hashers/BlindIndexHasherInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SpecShaper\EncryptBundle\Hashers;
+
+use SpecShaper\EncryptBundle\Annotations\BlindIndex;
+
+interface BlindIndexHasherInterface
+{
+    public function hash(?string $value, string $normalizer = BlindIndex::NORMALIZE_NONE): ?string;
+}

--- a/src/Hashers/HmacBlindIndexHasher.php
+++ b/src/Hashers/HmacBlindIndexHasher.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace SpecShaper\EncryptBundle\Hashers;
+
+use SpecShaper\EncryptBundle\Annotations\BlindIndex;
+use SpecShaper\EncryptBundle\Exception\EncryptException;
+
+final class HmacBlindIndexHasher implements BlindIndexHasherInterface
+{
+    public function __construct(
+        private readonly string $key
+    ) {
+    }
+
+    public function hash(?string $value, string $normalizer = BlindIndex::NORMALIZE_NONE): ?string
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        return hash_hmac('sha256', $this->normalize($value, $normalizer), $this->key);
+    }
+
+    private function normalize(string $value, string $normalizer): string
+    {
+        return match ($normalizer) {
+            BlindIndex::NORMALIZE_NONE => $value,
+            BlindIndex::NORMALIZE_TRIM => trim($value),
+            BlindIndex::NORMALIZE_LOWERCASE => mb_strtolower(trim($value)),
+            BlindIndex::NORMALIZE_UPPERCASE => mb_strtoupper(trim($value)),
+            default => throw new EncryptException(sprintf('Unknown blind index normalizer "%s".', $normalizer)),
+        };
+    }
+}

--- a/tests/Unit/Annotations/BlindIndexTest.php
+++ b/tests/Unit/Annotations/BlindIndexTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SpecShaper\EncryptBundle\Tests\Unit\Annotations;
+
+use PHPUnit\Framework\TestCase;
+use SpecShaper\EncryptBundle\Annotations\BlindIndex;
+
+class BlindIndexTest extends TestCase
+{
+    public function testSourceFieldAndNormalizerCanBeConfigured(): void
+    {
+        $attribute = new BlindIndex(
+            sourceField: 'email',
+            normalizer: BlindIndex::NORMALIZE_LOWERCASE
+        );
+
+        $this->assertSame('email', $attribute->getSourceField());
+        $this->assertSame(BlindIndex::NORMALIZE_LOWERCASE, $attribute->getNormalizer());
+    }
+}

--- a/tests/Unit/BlindIndex/BlindIndexUpdaterTest.php
+++ b/tests/Unit/BlindIndex/BlindIndexUpdaterTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace SpecShaper\EncryptBundle\Tests\Unit\BlindIndex;
+
+use PHPUnit\Framework\TestCase;
+use SpecShaper\EncryptBundle\Annotations\BlindIndex;
+use SpecShaper\EncryptBundle\BlindIndex\BlindIndexField;
+use SpecShaper\EncryptBundle\BlindIndex\BlindIndexUpdater;
+use SpecShaper\EncryptBundle\Exception\EncryptException;
+use SpecShaper\EncryptBundle\Hashers\HmacBlindIndexHasher;
+
+class BlindIndexUpdaterTest extends TestCase
+{
+    public function testUpdatesBlindIndexForChangedSourceField(): void
+    {
+        $entity = new BlindIndexUpdaterTestEntity();
+        $entity->email = '  Test@Example.COM  ';
+        $field = $this->createField('emailLookupHash', 'email');
+        $updater = new BlindIndexUpdater(new HmacBlindIndexHasher('secret'));
+
+        $updated = $updater->update($entity, [$field->getField() => $field], ['email' => [null, $entity->email]]);
+
+        $this->assertTrue($updated);
+        $this->assertSame(
+            hash_hmac('sha256', 'test@example.com', 'secret'),
+            $entity->emailLookupHash
+        );
+    }
+
+    public function testSkipsUnchangedSourceField(): void
+    {
+        $entity = new BlindIndexUpdaterTestEntity();
+        $entity->email = 'test@example.com';
+        $field = $this->createField('emailLookupHash', 'email');
+        $updater = new BlindIndexUpdater(new HmacBlindIndexHasher('secret'));
+
+        $updated = $updater->update($entity, [$field->getField() => $field], ['name' => [null, 'Test']]);
+
+        $this->assertFalse($updated);
+        $this->assertNull($entity->emailLookupHash);
+    }
+
+    public function testThrowsForObjectSourceValue(): void
+    {
+        $entity = new BlindIndexUpdaterTestEntity();
+        $entity->email = new \stdClass();
+        $field = $this->createField('emailLookupHash', 'email');
+        $updater = new BlindIndexUpdater(new HmacBlindIndexHasher('secret'));
+
+        $this->expectException(EncryptException::class);
+
+        $updater->update($entity, [$field->getField() => $field]);
+    }
+
+    private function createField(string $field, string $sourceField): BlindIndexField
+    {
+        return new BlindIndexField(
+            $field,
+            new \ReflectionProperty(BlindIndexUpdaterTestEntity::class, $field),
+            $sourceField,
+            new \ReflectionProperty(BlindIndexUpdaterTestEntity::class, $sourceField),
+            BlindIndex::NORMALIZE_LOWERCASE
+        );
+    }
+}
+
+class BlindIndexUpdaterTestEntity
+{
+    public mixed $email = null;
+
+    public ?string $emailLookupHash = null;
+
+    public ?string $name = null;
+}

--- a/tests/Unit/Hashers/HmacBlindIndexHasherTest.php
+++ b/tests/Unit/Hashers/HmacBlindIndexHasherTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace SpecShaper\EncryptBundle\Tests\Unit\Hashers;
+
+use PHPUnit\Framework\TestCase;
+use SpecShaper\EncryptBundle\Annotations\BlindIndex;
+use SpecShaper\EncryptBundle\Exception\EncryptException;
+use SpecShaper\EncryptBundle\Hashers\HmacBlindIndexHasher;
+
+class HmacBlindIndexHasherTest extends TestCase
+{
+    public function testHashUsesHmacSha256(): void
+    {
+        $hasher = new HmacBlindIndexHasher('secret');
+
+        $this->assertSame(
+            hash_hmac('sha256', 'test@example.com', 'secret'),
+            $hasher->hash('test@example.com')
+        );
+    }
+
+    public function testLowercaseNormalizerTrimsAndLowercasesValue(): void
+    {
+        $hasher = new HmacBlindIndexHasher('secret');
+
+        $this->assertSame(
+            $hasher->hash('test@example.com'),
+            $hasher->hash('  Test@Example.COM  ', BlindIndex::NORMALIZE_LOWERCASE)
+        );
+    }
+
+    public function testNullValueStaysNull(): void
+    {
+        $hasher = new HmacBlindIndexHasher('secret');
+
+        $this->assertNull($hasher->hash(null));
+    }
+
+    public function testUnknownNormalizerThrowsException(): void
+    {
+        $hasher = new HmacBlindIndexHasher('secret');
+
+        $this->expectException(EncryptException::class);
+
+        $hasher->hash('test@example.com', 'unknown');
+    }
+}


### PR DESCRIPTION
## Summary

Adds blind index support for encrypted fields so applications can enforce uniqueness and perform lookups without using deterministic encryption.

## Changes

- Add `BlindIndex` attribute for lookup hash columns
- Add HMAC-SHA256 blind index hasher service
- Add shared blind-index metadata provider and updater services
- Update Doctrine listener to maintain blind indexes when source fields change
- Add `encrypt:blind-index` command to rebuild lookup hashes through Doctrine
- Document encrypted value plus lookup hash usage
- Add unit tests for blind-index behavior